### PR TITLE
Automatically decode whole line and part of line

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -62,7 +62,8 @@ function updatePrettifiedJSON(context, searchKeyword = '', searchInputFocused = 
   const editor = vscode.window.activeTextEditor;
   if (editor) {
     const selection = editor.selection;
-    let textRaw = editor.document.getText(selection);
+
+    let textRaw = selection.isEmpty ? editor.document.getText(editor.document.lineAt(selection.active.line).range) : editor.document.getText(selection);
     if (!textRaw) {
       textRaw = '';
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pretty-json-preview",
-  "version": "0.0.47",
+  "version": "0.0.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pretty-json-preview",
-      "version": "0.0.47",
+      "version": "0.0.50",
       "license": "MIT",
       "dependencies": {
         "highlight.js": "^11.10.0",


### PR DESCRIPTION
This patch greatly improves usability by automatically decoding the whole line if an empty selection is present - in effect it means scrolling through JSONL in a file can be done quickly and easily.

The second commit builds on this by, in the line processing case, automatically trying to find a JSON start point along the line by splitting on start characters and attempting decoding. This in effect means lines of the form:

```
someprocess WARN { "my": "json", "logging": "here" }
```

can be browsed as is when opened.

Closes #2 

https://github.com/user-attachments/assets/e6bfaf5d-6362-4866-8f46-b55b7b796ac8

https://github.com/user-attachments/assets/6babb9c8-9c15-4e0c-9ab0-aff4a6d57b0a

